### PR TITLE
Fix mount errors

### DIFF
--- a/etc/sftp.d/gcs-mounts.sh
+++ b/etc/sftp.d/gcs-mounts.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # File mounted as: /etc/sftp.d/mount_user_directories.sh
+chmod 666 /dev/fuse
 
-runuser -l partner1 -c \
+runuser -l user1 -c \
 'export GOOGLE_APPLICATION_CREDENTIALS=/credentials/gcloud-key.json && \
 gcsfuse -o nonempty --only-dir user1 bucket /home/user1/ftp'
 
-runuser -l partner2 -c \
+runuser -l user2 -c \
 'export GOOGLE_APPLICATION_CREDENTIALS=/credentials/gcloud-key.json && \
 gcsfuse -o nonempty --only-dir user2 bucket /home/user2/ftp'


### PR DESCRIPTION
This is a fix for the following 2 errors:
- The partner1/partner2 -l params to `runuser` don't map to users in users.conf
- The lack of `chmod 666 /dev/fuse` was causing this an error: `fusermount: failed to open /dev/fuse: Permission denied1